### PR TITLE
feat: sync map state via backend

### DIFF
--- a/BattleTanks-Backend/Application/DTOs/MapCellDto.cs
+++ b/BattleTanks-Backend/Application/DTOs/MapCellDto.cs
@@ -2,5 +2,7 @@
 
 namespace Application.DTOs;
 
-// Represents a cell in the game map
-public record MapCellDto(int X, int Y, bool IsDestructible, bool IsDestroyed);
+// Represents a cell in the game map including its type
+// Type codes mirror the classic Battle City layout:
+// 0 = empty, 1 = destructible block, 2 = indestructible block, 3 = base
+public record MapCellDto(int X, int Y, int Type, bool IsDestructible, bool IsDestroyed);

--- a/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
@@ -188,8 +188,8 @@ internal sealed class InMemoryRoomRegistry : IRoomRegistry
             for (int x = 0; x < layout.GetLength(1); x++)
             {
                 int val = layout[y, x];
-                bool destructible = val == 1;
-                room.MapCells[(x, y)] = new MapCellDto(x, y, destructible, false);
+                bool destructible = val == 1 || val == 3;
+                room.MapCells[(x, y)] = new MapCellDto(x, y, val, destructible, false);
             }
         }
 

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -25,6 +25,8 @@ export class SignalRService {
   readonly playerDied$ = new Subject<string>();
   readonly reconnected$ = new Subject<void>();
   readonly disconnected$ = new Subject<void>();
+  readonly mapState$ = new Subject<any[]>();
+  readonly cellDestroyed$ = new Subject<any>();
 
   get isConnected() {
     return !!this.hub && this.hub.state === 'Connected';
@@ -80,6 +82,16 @@ export class SignalRService {
     this.hub.on('playerDied', (playerId: string) => {
       console.log('[SignalR] playerDied:', playerId);
       this.playerDied$.next(playerId);
+    });
+
+    this.hub.on('mapState', (map: any[]) => {
+      console.log('[SignalR] mapState:', map);
+      this.mapState$.next(map);
+    });
+
+    this.hub.on('cellDestroyed', (cell: any) => {
+      console.log('[SignalR] cellDestroyed:', cell);
+      this.cellDestroyed$.next(cell);
     });
 
     this.hub.on('eventHistory', (history: any) => {
@@ -192,5 +204,17 @@ export class SignalRService {
     if (!this.hub) throw new Error('Hub not connected');
     console.log('[SignalR] reportBulletCollision:', bulletId);
     await this.hub.invoke('ReportObstacleHit', bulletId);
+  }
+
+  async getMap(): Promise<void> {
+    if (!this.hub) throw new Error('Hub not connected');
+    console.log('[SignalR] getMap');
+    await this.hub.invoke('GetMap');
+  }
+
+  async destroyCell(x: number, y: number): Promise<void> {
+    if (!this.hub) throw new Error('Hub not connected');
+    console.log('[SignalR] destroyCell:', { x, y });
+    await this.hub.invoke('DestroyCell', x, y);
   }
 }


### PR DESCRIPTION
## Summary
- send detailed map cells from backend including cell type
- add SignalR events and client handling to fetch map and apply cell destruction
- update room canvas to request server map and react to updates

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b0e9a76da08330a63a8f50b945765f