### PR TITLE
Disable player actions after elimination

### DIFF
--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Bullets.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Bullets.cs
@@ -16,6 +16,13 @@ public partial class GameHub : Hub
     {
         if (!_tracker.TryGet(Context.ConnectionId, out var info)) throw new HubException("not_in_room");
 
+        if (_playerLivesByRoom.TryGetValue(info.RoomCode, out var livesDict)
+            && livesDict.TryGetValue(info.UserId, out var lives)
+            && lives <= 0)
+        {
+            return string.Empty;
+        }
+
         var normalizedRotation = NormalizeAngle(rotation);
         var clampedSpeed = Clamp(speed, 0.1f, 100f);
 

--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
@@ -166,6 +166,13 @@ public partial class GameHub : Hub
         if (!_tracker.TryGet(Context.ConnectionId, out var info))
             throw new HubException("not_in_room");
 
+        if (_playerLivesByRoom.TryGetValue(info.RoomCode, out var livesDict)
+            && livesDict.TryGetValue(info.UserId, out var lives)
+            && lives <= 0)
+        {
+            return;
+        }
+
         if (float.IsNaN(position.X) || float.IsInfinity(position.X) ||
             float.IsNaN(position.Y) || float.IsInfinity(position.Y) ||
             float.IsNaN(position.Rotation) || float.IsInfinity(position.Rotation))

--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -150,6 +150,12 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
     }
   });
 
+  private _stopInputEffect = effect(() => {
+    if (!this.isCurrentPlayerAlive()) {
+      this.pressed.clear();
+    }
+  });
+
   ngAfterViewInit(): void {
     const canvas = this.canvasRef.nativeElement;
     this.ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary
- prevent players with zero lives from spawning bullets or moving
- clear client input state when player dies to stop movement/shooting

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b22b8d96d48330a415b0ea375caaad