### PR TITLE
feat: require players to ready before game start

### DIFF
--- a/BattleTanks-Backend/Application/DTOs/PlayerStateDto.cs
+++ b/BattleTanks-Backend/Application/DTOs/PlayerStateDto.cs
@@ -10,5 +10,6 @@ public record PlayerStateDto(
     bool IsAlive,
     int Score,
     bool HasShield,
-    float Speed
+    float Speed,
+    bool IsReady = false
 );

--- a/BattleTanks-Backend/Application/Services/GameService.cs
+++ b/BattleTanks-Backend/Application/Services/GameService.cs
@@ -230,7 +230,8 @@ public class GameService : IGameService
             player.IsAlive,
             player.SessionScore,
             false,
-            200
+            200,
+            player.IsReady
         );
     }
 }

--- a/BattleTanks-Backend/Domain/Entities/Player.cs
+++ b/BattleTanks-Backend/Domain/Entities/Player.cs
@@ -16,6 +16,7 @@ public class Player
     public int SessionKills { get; private set; }
     public int SessionDeaths { get; private set; }
     public int SessionScore { get; private set; }
+    public bool IsReady { get; private set; }
     
     // Navegación
     public User User { get; private set; }
@@ -37,7 +38,8 @@ public class Player
             Health = 100,
             SessionKills = 0,
             SessionDeaths = 0,
-            SessionScore = 0
+            SessionScore = 0,
+            IsReady = false
         };
     }
     
@@ -45,12 +47,14 @@ public class Player
     {
         GameSessionId = gameSessionId;
         ResetSessionStats();
+        IsReady = false;
     }
     
     public void LeaveGameSession()
     {
         GameSessionId = null;
         ResetSessionStats();
+        IsReady = false;
     }
     
     public void UpdatePosition(Position newPosition, float rotation)
@@ -95,6 +99,12 @@ public class Player
         SessionKills = 0;
         SessionDeaths = 0;
         SessionScore = 0;
+        IsReady = false;
+    }
+
+    public void SetReady(bool ready)
+    {
+        IsReady = ready;
     }
     
     // Propiedades de conveniencia

--- a/BattleTanks-Backend/Infrastructure/SignalR/Abstractions/IRoomRegistry.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Abstractions/IRoomRegistry.cs
@@ -36,6 +36,9 @@ public interface IRoomRegistry
     // Update a player's lives/score
     Task UpdatePlayerStatsAsync(string roomCode, string playerId, int lives, int score, bool isAlive);
 
+    // Update ready status
+    Task SetPlayerReadyAsync(string roomCode, string playerId, bool ready);
+
     // Get map snapshot
     Task<MapCellDto[]> GetMapAsync(string roomId);
 

--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
@@ -48,6 +48,10 @@ public partial class GameHub : Hub
         {
             await _rooms.JoinAsync(roomCode, userId, uname, Context.ConnectionId);
         }
+        catch (InvalidOperationException ex) when (ex.Message == "room_already_started")
+        {
+            throw new HubException("room_in_progress");
+        }
         catch
         {
             throw new HubException("room_not_found");
@@ -196,5 +200,13 @@ public partial class GameHub : Hub
             await _history.AddEventAsync(info.RoomCode, "playerMoved", fixedDto);
         }
         catch { }
+    }
+
+    public async Task SetReady(bool ready)
+    {
+        if (!_tracker.TryGet(Context.ConnectionId, out var info))
+            throw new HubException("not_in_room");
+
+        await _rooms.SetPlayerReadyAsync(info.RoomCode, info.UserId, ready);
     }
 }

--- a/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Services/InMemoryRoomRegistry.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Linq;
 using Application.DTOs;
 using Application.Interfaces;
 using Domain.Enums;
@@ -92,6 +93,9 @@ internal sealed class InMemoryRoomRegistry : IRoomRegistry
     public async Task JoinAsync(string roomCode, string userId, string username, string connectionId)
     {
         var room = await EnsureRoomByCodeAsync(roomCode);
+        if (room.Status != GameRoomStatus.Waiting.ToString())
+            throw new InvalidOperationException("room_already_started");
+
         var state = new PlayerStateDto(userId, username, 0, 0, 0, 3, true, 0, false, 200);
         room.Players[userId] = state;
         _connIndex[connectionId] = (roomCode, userId);
@@ -127,6 +131,27 @@ internal sealed class InMemoryRoomRegistry : IRoomRegistry
             }
         }
         return Task.CompletedTask;
+    }
+
+    public async Task SetPlayerReadyAsync(string roomCode, string playerId, bool ready)
+    {
+        if (_codeToId.TryGetValue(roomCode, out var roomId) && _byId.TryGetValue(roomId, out var room))
+        {
+            if (room.Players.TryGetValue(playerId, out var state))
+            {
+                room.Players[playerId] = state with { IsReady = ready };
+                await _hub.Clients.Group(room.RoomCode).SendAsync("playerReady", new { userId = playerId, ready });
+
+                if (room.Status == GameRoomStatus.Waiting.ToString() &&
+                    room.Players.Count >= 2 &&
+                    room.Players.Values.All(p => p.IsReady))
+                {
+                    ResetMap(room);
+                    room.Status = GameRoomStatus.InProgress.ToString();
+                    await _hub.Clients.Group(room.RoomCode).SendAsync("gameStarted");
+                }
+            }
+        }
     }
 
     // Ensure room exists and initialize map if missing
@@ -171,6 +196,15 @@ internal sealed class InMemoryRoomRegistry : IRoomRegistry
             r.Status,
             r.Players
         );
+
+    private static void ResetMap(Room room)
+    {
+        room.MapCells.Clear();
+        room.SpawnPoints.Clear();
+        room.PowerUps.Clear();
+        room.NextSpawnIndex = 0;
+        InitializeMap(room);
+    }
 
     // Initialize default map and spawn points
     private static void InitializeMap(Room room)

--- a/BattleTanks-Frontend/src/app/core/models/game.models.ts
+++ b/BattleTanks-Frontend/src/app/core/models/game.models.ts
@@ -9,6 +9,7 @@ export interface PlayerStateDto {
   score: number;
   hasShield: boolean;
   speed: number;
+  isReady: boolean;
 }
 
 export interface PlayerPositionDto {

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -31,6 +31,8 @@ export class SignalRService {
   readonly powerUpSpawned$ = new Subject<PowerUpDto>();
   readonly powerUpRemoved$ = new Subject<string>();
   readonly powerUpState$ = new Subject<PowerUpDto[]>();
+  readonly playerReady$ = new Subject<{ userId: string; ready: boolean }>();
+  readonly gameStarted$ = new Subject<void>();
 
   get isConnected() {
     return !!this.hub && this.hub.state === 'Connected';
@@ -86,6 +88,16 @@ export class SignalRService {
     this.hub.on('playerDied', (playerId: string) => {
       console.log('[SignalR] playerDied:', playerId);
       this.playerDied$.next(playerId);
+    });
+
+    this.hub.on('playerReady', (payload: { userId: string; ready: boolean }) => {
+      console.log('[SignalR] playerReady:', payload);
+      this.playerReady$.next(payload);
+    });
+
+    this.hub.on('gameStarted', () => {
+      console.log('[SignalR] gameStarted');
+      this.gameStarted$.next();
     });
 
     this.hub.on('mapState', (map: any[]) => {
@@ -247,5 +259,11 @@ export class SignalRService {
     if (!this.hub) throw new Error('Hub not connected');
     console.log('[SignalR] collectPowerUp:', id);
     await this.hub.invoke('CollectPowerUp', id);
+  }
+
+  async setReady(ready: boolean): Promise<void> {
+    if (!this.hub) throw new Error('Hub not connected');
+    console.log('[SignalR] setReady:', ready);
+    await this.hub.invoke('SetReady', ready);
   }
 }

--- a/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -13,42 +13,55 @@
     }
 
     @if (joined()) {
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 relative">
-          @if (!myAlive()) {
-            <div class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/80 text-red-300 rounded-md px-4 py-8 space-y-3">
-              <h2 class="text-lg">¡Has perdido!</h2>
-              <p class="text-xs">Te quedaste sin vidas.</p>
-              <a routerLink="/lobby" class="pixel-btn text-xs">Volver al lobby</a>
-            </div>
-          }
-          <div class="lg:col-span-2 relative">
-            @if (myLives() !== null) {
-              <div class="absolute top-0 right-0 mt-1 mr-2 text-xs text-yellow-300 font-mono select-none">
-                Vidas: {{ myLives() }} · Puntos: {{ myScore() }}
+      @if (gameStarted()) {
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 relative">
+            @if (!myAlive()) {
+              <div class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/80 text-red-300 rounded-md px-4 py-8 space-y-3">
+                <h2 class="text-lg">¡Has perdido!</h2>
+                <p class="text-xs">Te quedaste sin vidas.</p>
+                <a routerLink="/lobby" class="pixel-btn text-xs">Volver al lobby</a>
               </div>
             }
-            <app-room-canvas />
-          </div>
-          <div>
-            <div class="mb-4 text-xs text-yellow-300">
-              <h2 class="font-bold mb-1">Jugadores</h2>
-              <ul class="space-y-1">
-                @for (p of players(); track p.playerId) {
-                  <li>
-                    {{ p.username }} - Vidas: {{ p.lives }} - Puntos: {{ p.score }}
-                    @if (!p.isAlive) {
-                      <span class="text-red-400 ml-1">Game Over</span>
-                    }
-                  </li>
-                }
-              </ul>
+            <div class="lg:col-span-2 relative">
+              @if (myLives() !== null) {
+                <div class="absolute top-0 right-0 mt-1 mr-2 text-xs text-yellow-300 font-mono select-none">
+                  Vidas: {{ myLives() }} · Puntos: {{ myScore() }}
+                </div>
+              }
+              <app-room-canvas />
             </div>
-            <app-chat-panel />
+            <div>
+              <div class="mb-4 text-xs text-yellow-300">
+                <h2 class="font-bold mb-1">Jugadores</h2>
+                <ul class="space-y-1">
+                  @for (p of players(); track p.playerId) {
+                    <li>
+                      {{ p.username }} - Vidas: {{ p.lives }} - Puntos: {{ p.score }}
+                      @if (!p.isAlive) {
+                        <span class="text-red-400 ml-1">Game Over</span>
+                      }
+                    </li>
+                  }
+                </ul>
+              </div>
+              <app-chat-panel />
+            </div>
           </div>
-        </div>
       } @else {
-        <div class="text-blue-300 text-sm">Conectando a la sala...</div>
+        <div class="text-yellow-300 text-sm mb-4">Esperando a que todos estén listos...</div>
+        <button class="pixel-btn text-xs mb-4" (click)="sendReady()" [disabled]="myReady()">Listo</button>
+        <div class="text-xs text-yellow-300">
+          <h2 class="font-bold mb-1">Jugadores</h2>
+          <ul class="space-y-1">
+            @for (p of players(); track p.playerId) {
+              <li>{{ p.username }} - {{ p.isReady ? 'Listo' : 'Esperando' }}</li>
+            }
+          </ul>
+        </div>
       }
+    } @else {
+      <div class="text-blue-300 text-sm">Conectando a la sala...</div>
+    }
 
     <div class="scanline"></div>
   </div>

--- a/BattleTanks-Frontend/src/app/features/room/room.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.ts
@@ -5,7 +5,7 @@ import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import { roomActions } from './store/room.actions';
-import { selectHubConnected, selectJoined, selectRoomError, selectPlayers } from './store/room.selectors';
+import { selectHubConnected, selectJoined, selectRoomError, selectPlayers, selectGameStarted } from './store/room.selectors';
 import { selectUser } from './../auth/store/auth.selectors';
 import { RoomCanvasComponent } from './room-canvas/room-canvas.component';
 import { ChatPanelComponent } from './chat-panel/chat-panel.component';
@@ -26,6 +26,7 @@ export class RoomComponent implements OnInit, OnDestroy {
   joined       = toSignal(this.store.select(selectJoined),       { initialValue: false });
   error        = toSignal(this.store.select(selectRoomError),    { initialValue: null });
   user         = toSignal(this.store.select(selectUser),         { initialValue: null });
+  gameStarted  = toSignal(this.store.select(selectGameStarted),  { initialValue: false });
 
   /**
    * Signal containing the list of players in the current room.  Used to derive the current player's
@@ -59,6 +60,11 @@ export class RoomComponent implements OnInit, OnDestroy {
       return p ? p.score : 0;
     });
 
+    myReady = computed(() => {
+      const p = this.myPlayer();
+      return p ? p.isReady : false;
+    });
+
   /**
    * Indicates whether the current player is still alive.  Defaults to true (so that UI does not show
    * an overlay before joining).
@@ -90,5 +96,9 @@ export class RoomComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.store.dispatch(roomActions.leaveRoom());
+  }
+
+  sendReady() {
+    this.store.dispatch(roomActions.setReady({ ready: true }));
   }
 }

--- a/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -35,10 +35,13 @@ export const roomActions = createActionGroup({
     'Player Hit': props<{ dto: PlayerHitDto }>(),
     'Player Died': props<{ playerId: string }>(),
     'Message Received': props<{ msg: ChatMessageDto }>(),
+    'Player Ready': props<{ userId: string; ready: boolean }>(),
+    'Game Started': emptyProps(),
 
     // Cliente→servidor
     'Send Message': props<{ content: string }>(),
     'Update Position': props<{ dto: PlayerPositionDto }>(),
     'Spawn Bullet': props<{ x: number; y: number; dir: number; speed: number }>(),
+    'Set Ready': props<{ ready: boolean }>(),
   },
 });

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -46,6 +46,8 @@ events$ = createEffect(() =>
         this.hub.bulletDespawned$.pipe(map(({ bulletId }) => roomActions.bulletDespawned({ bulletId }))),
         this.hub.playerHit$.pipe(map((dto) => roomActions.playerHit({ dto }))),
         this.hub.playerDied$.pipe(map((playerId) => roomActions.playerDied({ playerId }))),
+        this.hub.playerReady$.pipe(map((p) => roomActions.playerReady(p))),
+        this.hub.gameStarted$.pipe(map(() => roomActions.gameStarted())),
         // MQTT events
         this.mqtt.playerJoined$.pipe(map((p) => roomActions.playerJoined(p))),
         this.mqtt.playerLeft$.pipe(map((userId) => roomActions.playerLeft({ userId }))),
@@ -140,6 +142,15 @@ events$ = createEffect(() =>
       this.actions$.pipe(
         ofType(roomActions.spawnBullet),
         mergeMap(({ x, y, dir, speed }) => from(this.hub.spawnBullet(x, y, dir, speed)).pipe(catchError(() => of(void 0))))
+      ),
+    { dispatch: false }
+  );
+
+  setReady$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(roomActions.setReady),
+        mergeMap(({ ready }) => from(this.hub.setReady(ready)).pipe(catchError(() => of(void 0))))
       ),
     { dispatch: false }
   );

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -8,6 +8,7 @@ export const selectHubConnected = createSelector(selectRoomState, (s) => s.hubCo
 export const selectJoined = createSelector(selectRoomState, (s) => s.joined);
 export const selectRoomError = createSelector(selectRoomState, (s) => s.error);
 export const selectChat = createSelector(selectRoomState, (s) => s.chat);
+export const selectGameStarted = createSelector(selectRoomState, (s) => s.gameStarted);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();


### PR DESCRIPTION
## Summary
- track per-player ready state and start rooms only when all players confirm
- add SignalR and Angular flows for players to mark themselves ready
- show lobby waiting screen with ready button until the match begins

## Testing
- ⚠️ `dotnet build` *(command not found)*
- ✅ `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b78a3cd2d083308a9325919fdabfee