### PR TITLE
Optimize auth endpoints with caching and async improvements

### DIFF
--- a/BattleTanks-Backend/Application/Application.csproj
+++ b/BattleTanks-Backend/Application/Application.csproj
@@ -13,6 +13,7 @@
     <ItemGroup>
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
       <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
+      <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     </ItemGroup>
 
 </Project>

--- a/BattleTanks-Backend/Application/Interfaces/IUserRepository.cs
+++ b/BattleTanks-Backend/Application/Interfaces/IUserRepository.cs
@@ -7,9 +7,11 @@ public interface IUserRepository
     Task<User?> GetByIdAsync(Guid id);
     Task<User?> GetByUsernameAsync(string username);
     Task<User?> GetByEmailAsync(string email);
+    Task<User?> GetByUsernameOrEmailAsync(string usernameOrEmail);
     Task<List<User>> GetTopPlayersByScoreAsync(int limit = 10);
     Task<bool> ExistsByUsernameAsync(string username);
     Task<bool> ExistsByEmailAsync(string email);
+    Task UpdateLastLoginAsync(Guid id);
     Task AddAsync(User user);
     Task UpdateAsync(User user);
     Task DeleteAsync(Guid id);

--- a/BattleTanks-Backend/Application/Services/AuthService.cs
+++ b/BattleTanks-Backend/Application/Services/AuthService.cs
@@ -2,16 +2,19 @@ using Application.DTOs;
 using Application.Interfaces;
 using Domain.Entities;
 using BCrypt.Net;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Application.Services;
 
 public class AuthService : IAuthService
 {
     private readonly IUserRepository _userRepository;
+    private readonly IMemoryCache _cache;
 
-    public AuthService(IUserRepository userRepository)
+    public AuthService(IUserRepository userRepository, IMemoryCache cache)
     {
         _userRepository = userRepository;
+        _cache = cache;
     }
 
     // Register new user
@@ -20,33 +23,48 @@ public class AuthService : IAuthService
         if (registerDto.Password != registerDto.ConfirmPassword)
             throw new ArgumentException("Passwords don't match");
 
-        if (await _userRepository.ExistsByUsernameAsync(registerDto.Username))
+        var usernameExistsTask = _userRepository.ExistsByUsernameAsync(registerDto.Username);
+        var emailExistsTask = _userRepository.ExistsByEmailAsync(registerDto.Email);
+        await Task.WhenAll(usernameExistsTask, emailExistsTask);
+
+        if (usernameExistsTask.Result)
             throw new ArgumentException("Username already exists");
 
-        if (await _userRepository.ExistsByEmailAsync(registerDto.Email))
+        if (emailExistsTask.Result)
             throw new ArgumentException("Email already exists");
 
-        var passwordHash = BCrypt.Net.BCrypt.HashPassword(registerDto.Password);
+        var passwordHash = await Task.Run(() => BCrypt.Net.BCrypt.HashPassword(registerDto.Password));
         var user = User.Create(registerDto.Username, registerDto.Email, passwordHash);
-        
+
         await _userRepository.AddAsync(user);
+        _cache.Set($"user:{user.Username.ToLowerInvariant()}", user, TimeSpan.FromMinutes(5));
+        _cache.Set($"user:{user.Email}", user, TimeSpan.FromMinutes(5));
         return user;
     }
 
     // Login user
     public async Task<User> LoginAsync(LoginDto loginDto)
     {
-        var user = await _userRepository.GetByUsernameAsync(loginDto.UsernameOrEmail) ??
-                   await _userRepository.GetByEmailAsync(loginDto.UsernameOrEmail);
+        var cacheKey = $"user:{loginDto.UsernameOrEmail.ToLowerInvariant()}";
+        if (!_cache.TryGetValue(cacheKey, out User? user))
+        {
+            user = await _userRepository.GetByUsernameOrEmailAsync(loginDto.UsernameOrEmail);
+            if (user != null)
+            {
+                _cache.Set(cacheKey, user, TimeSpan.FromMinutes(5));
+            }
+        }
 
         if (user == null)
             throw new UnauthorizedAccessException("Invalid credentials");
 
-        if (!BCrypt.Net.BCrypt.Verify(loginDto.Password, user.PasswordHash))
+        var validPassword = await Task.Run(() => BCrypt.Net.BCrypt.Verify(loginDto.Password, user.PasswordHash));
+        if (!validPassword)
             throw new UnauthorizedAccessException("Invalid credentials");
 
         user.UpdateLastLogin();
-        await _userRepository.UpdateAsync(user);
+        await _userRepository.UpdateLastLoginAsync(user.Id);
+        _cache.Set(cacheKey, user, TimeSpan.FromMinutes(5));
 
         return user;
     }

--- a/BattleTanks-Backend/BattleTanks-Backend/Program.cs
+++ b/BattleTanks-Backend/BattleTanks-Backend/Program.cs
@@ -22,6 +22,7 @@ builder.Services.AddControllers(options =>
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddMemoryCache();
 
 // JWT options
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));

--- a/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfUserRepository.cs
+++ b/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfUserRepository.cs
@@ -1,6 +1,8 @@
 using Application.Interfaces;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
 
 namespace Infrastructure.Persistence.Repositories;
 
@@ -35,6 +37,14 @@ public class EfUserRepository : IUserRepository
             .FirstOrDefaultAsync(u => u.Email == email.ToLowerInvariant());
     }
 
+    public async Task<User?> GetByUsernameOrEmailAsync(string usernameOrEmail)
+    {
+        var normalized = usernameOrEmail.ToLowerInvariant();
+        return await _context.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Username == usernameOrEmail || u.Email == normalized);
+    }
+
     public async Task<List<User>> GetTopPlayersByScoreAsync(int limit = 10)
     {
         return await _context.Users
@@ -57,6 +67,13 @@ public class EfUserRepository : IUserRepository
         return await _context.Users
             .AsNoTracking()
             .AnyAsync(u => u.Email == email.ToLowerInvariant());
+    }
+
+    public async Task UpdateLastLoginAsync(Guid id)
+    {
+        await _context.Users
+            .Where(u => u.Id == id)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(u => u.LastLoginAt, DateTime.UtcNow));
     }
 
     public async Task AddAsync(User user)


### PR DESCRIPTION
## Summary
- parallelize duplicate checks and hash tasks in registration
- cache user lookups and condense login into single query
- track last login with lightweight update and register memory cache

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b7bf5096d88330a0230488a5d14aa9