### PR TITLE
Implement game finalization and winner/loser notifications

### DIFF
--- a/BattleTanks-Frontend/src/app/core/services/mqtt.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/mqtt.service.ts
@@ -24,6 +24,7 @@ export class MqttService {
   readonly bulletDespawned$ = new Subject<{ bulletId: string; reason: string }>();
   readonly playerHit$ = new Subject<PlayerHitDto>();
   readonly playerDied$ = new Subject<string>();
+  readonly gameFinished$ = new Subject<string | null>();
 
   connect(roomCode: string): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -98,6 +99,9 @@ export class MqttService {
             case 'playerDied':
               const id = typeof data === 'string' ? data : data.playerId;
               this.playerDied$.next(id);
+              break;
+            case 'gameFinished':
+              this.gameFinished$.next(data?.winnerId ?? null);
               break;
             default:
               console.warn('[MQTT] Unknown event type received:', eventType, data);

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -33,6 +33,7 @@ export class SignalRService {
   readonly powerUpState$ = new Subject<PowerUpDto[]>();
   readonly playerReady$ = new Subject<{ userId: string; ready: boolean }>();
   readonly gameStarted$ = new Subject<void>();
+  readonly gameFinished$ = new Subject<string | null>();
 
   get isConnected() {
     return !!this.hub && this.hub.state === 'Connected';
@@ -98,6 +99,11 @@ export class SignalRService {
     this.hub.on('gameStarted', () => {
       console.log('[SignalR] gameStarted');
       this.gameStarted$.next();
+    });
+
+    this.hub.on('gameFinished', (winnerId: string | null) => {
+      console.log('[SignalR] gameFinished:', winnerId);
+      this.gameFinished$.next(winnerId);
     });
 
     this.hub.on('mapState', (map: any[]) => {

--- a/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -15,10 +15,9 @@
     @if (joined()) {
       @if (gameStarted()) {
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 relative">
-            @if (!myAlive()) {
-              <div class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/80 text-red-300 rounded-md px-4 py-8 space-y-3">
-                <h2 class="text-lg">¡Has perdido!</h2>
-                <p class="text-xs">Te quedaste sin vidas.</p>
+            @if (gameFinished()) {
+              <div class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/80 text-yellow-300 rounded-md px-4 py-8 space-y-3">
+                <h2 class="text-lg">{{ myPlayer()?.playerId === winnerId() ? '¡Ganaste!' : '¡Has perdido!' }}</h2>
                 <a routerLink="/lobby" class="pixel-btn text-xs">Volver al lobby</a>
               </div>
             }

--- a/BattleTanks-Frontend/src/app/features/room/room.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.ts
@@ -5,7 +5,15 @@ import { Store } from '@ngrx/store';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 import { roomActions } from './store/room.actions';
-import { selectHubConnected, selectJoined, selectRoomError, selectPlayers, selectGameStarted } from './store/room.selectors';
+import {
+  selectHubConnected,
+  selectJoined,
+  selectRoomError,
+  selectPlayers,
+  selectGameStarted,
+  selectGameFinished,
+  selectWinnerId,
+} from './store/room.selectors';
 import { selectUser } from './../auth/store/auth.selectors';
 import { RoomCanvasComponent } from './room-canvas/room-canvas.component';
 import { ChatPanelComponent } from './chat-panel/chat-panel.component';
@@ -27,6 +35,8 @@ export class RoomComponent implements OnInit, OnDestroy {
   error        = toSignal(this.store.select(selectRoomError),    { initialValue: null });
   user         = toSignal(this.store.select(selectUser),         { initialValue: null });
   gameStarted  = toSignal(this.store.select(selectGameStarted),  { initialValue: false });
+  gameFinished = toSignal(this.store.select(selectGameFinished), { initialValue: false });
+  winnerId     = toSignal(this.store.select(selectWinnerId),     { initialValue: null });
 
   /**
    * Signal containing the list of players in the current room.  Used to derive the current player's

--- a/BattleTanks-Frontend/src/app/features/room/room.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.ts
@@ -13,6 +13,7 @@ import {
   selectGameStarted,
   selectGameFinished,
   selectWinnerId,
+  selectLastUsername,
 } from './store/room.selectors';
 import { selectUser } from './../auth/store/auth.selectors';
 import { RoomCanvasComponent } from './room-canvas/room-canvas.component';
@@ -34,6 +35,7 @@ export class RoomComponent implements OnInit, OnDestroy {
   joined       = toSignal(this.store.select(selectJoined),       { initialValue: false });
   error        = toSignal(this.store.select(selectRoomError),    { initialValue: null });
   user         = toSignal(this.store.select(selectUser),         { initialValue: null });
+  lastUsername = toSignal(this.store.select(selectLastUsername), { initialValue: null });
   gameStarted  = toSignal(this.store.select(selectGameStarted),  { initialValue: false });
   gameFinished = toSignal(this.store.select(selectGameFinished), { initialValue: false });
   winnerId     = toSignal(this.store.select(selectWinnerId),     { initialValue: null });
@@ -49,12 +51,15 @@ export class RoomComponent implements OnInit, OnDestroy {
    * against the list of players.  Returns null if the player has not yet joined the room.
    */
   myPlayer = computed(() => {
-    const me = this.user();
     const roster = this.players();
-    if (!me) return null;
-    const myId   = me.id;
-    const myName = me.username?.toLowerCase() ?? '';
-    return roster.find(p => p.playerId === myId || (p.username?.toLowerCase() ?? '') === myName) ?? null;
+    const me = this.user();
+    if (me) {
+      const myId = me.id;
+      const myName = me.username?.toLowerCase() ?? '';
+      return roster.find(p => p.playerId === myId || (p.username?.toLowerCase() ?? '') === myName) ?? null;
+    }
+    const last = this.lastUsername()?.toLowerCase() ?? '';
+    return roster.find(p => (p.username?.toLowerCase() ?? '') === last) ?? null;
   });
 
   /**

--- a/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -37,6 +37,7 @@ export const roomActions = createActionGroup({
     'Message Received': props<{ msg: ChatMessageDto }>(),
     'Player Ready': props<{ userId: string; ready: boolean }>(),
     'Game Started': emptyProps(),
+    'Game Finished': props<{ winnerId: string | null }>(),
 
     // Cliente→servidor
     'Send Message': props<{ content: string }>(),

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -20,6 +20,7 @@ class SignalRServiceMock {
   bulletDespawned$ = new Subject<{ bulletId: string; reason: string }>();
   reconnected$ = new Subject<void>();
   disconnected$ = new Subject<void>();
+  gameFinished$ = new Subject<string | null>();
 
   connect = jasmine.createSpy('connect').and.returnValue(Promise.resolve());
   disconnect = jasmine.createSpy('disconnect').and.returnValue(Promise.resolve());

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -48,6 +48,7 @@ events$ = createEffect(() =>
         this.hub.playerDied$.pipe(map((playerId) => roomActions.playerDied({ playerId }))),
         this.hub.playerReady$.pipe(map((p) => roomActions.playerReady(p))),
         this.hub.gameStarted$.pipe(map(() => roomActions.gameStarted())),
+        this.hub.gameFinished$.pipe(map((winnerId) => roomActions.gameFinished({ winnerId }))),
         // MQTT events
         this.mqtt.playerJoined$.pipe(map((p) => roomActions.playerJoined(p))),
         this.mqtt.playerLeft$.pipe(map((userId) => roomActions.playerLeft({ userId }))),
@@ -56,7 +57,8 @@ events$ = createEffect(() =>
         this.mqtt.bulletSpawned$.pipe(map((bullet) => roomActions.bulletSpawned({ bullet }))),
         this.mqtt.bulletDespawned$.pipe(map(({ bulletId }) => roomActions.bulletDespawned({ bulletId }))),
         this.mqtt.playerHit$.pipe(map((dto) => roomActions.playerHit({ dto }))),
-        this.mqtt.playerDied$.pipe(map((playerId) => roomActions.playerDied({ playerId })))
+        this.mqtt.playerDied$.pipe(map((playerId) => roomActions.playerDied({ playerId }))),
+        this.mqtt.gameFinished$.pipe(map((winnerId) => roomActions.gameFinished({ winnerId })))
       ).pipe(takeUntil(stop$));
     })
   )

--- a/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.reducer.spec.ts
@@ -15,6 +15,9 @@ describe('Room Reducer', () => {
       bullets: roomBulletsAdapter.getInitialState(),
       chat: [],
       lastUsername: null,
+      gameStarted: false,
+      gameFinished: false,
+      winnerId: null,
     };
   });
 

--- a/BattleTanks-Frontend/src/app/features/room/store/room.reducer.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.reducer.ts
@@ -16,6 +16,8 @@ export interface RoomState {
   chat: ChatMessageDto[];
   lastUsername: string | null;
   gameStarted: boolean;
+  gameFinished: boolean;
+  winnerId: string | null;
 }
 
 const playersAdapter = createEntityAdapter<PlayerEntity>({
@@ -35,6 +37,8 @@ const initialState: RoomState = {
   chat: [],
   lastUsername: null,
   gameStarted: false,
+  gameFinished: false,
+  winnerId: null,
 };
 
 export const roomReducer = createReducer(
@@ -47,8 +51,8 @@ export const roomReducer = createReducer(
   on(roomActions.hubError, (s, { error }) => ({ ...s, error })),
 
   // Room lifecycle
-  on(roomActions.joinRoom, (s, { code, username }) => ({ ...s, roomCode: code, lastUsername: username, error: null })),
-  on(roomActions.joined, (s) => ({ ...s, joined: true, gameStarted: false })),
+  on(roomActions.joinRoom, (s, { code, username }) => ({ ...s, roomCode: code, lastUsername: username, error: null, gameFinished: false, winnerId: null })),
+  on(roomActions.joined, (s) => ({ ...s, joined: true, gameStarted: false, gameFinished: false, winnerId: null })),
   on(roomActions.leaveRoom, (s) => ({ ...s, joined: false })),
   on(roomActions.left, (s) => ({
     ...s,
@@ -58,6 +62,8 @@ export const roomReducer = createReducer(
     bullets: bulletsAdapter.removeAll(s.bullets),
     chat: [],
     gameStarted: false,
+    gameFinished: false,
+    winnerId: null,
   })),
 
   // Player events
@@ -170,6 +176,7 @@ export const roomReducer = createReducer(
   }),
 
   on(roomActions.gameStarted, (s) => ({ ...s, gameStarted: true })),
+  on(roomActions.gameFinished, (s, { winnerId }) => ({ ...s, gameFinished: true, winnerId })),
 
   // Chat messages
   on(roomActions.messageReceived, (s, { msg }) => ({

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
@@ -24,6 +24,9 @@ describe('Room Selectors', () => {
       bullets,
       chat: [],
       lastUsername: 'juan',
+      gameStarted: false,
+      gameFinished: false,
+      winnerId: null,
     };
     state = { room };
   });

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -11,6 +11,7 @@ export const selectChat = createSelector(selectRoomState, (s) => s.chat);
 export const selectGameStarted = createSelector(selectRoomState, (s) => s.gameStarted);
 export const selectGameFinished = createSelector(selectRoomState, (s) => s.gameFinished);
 export const selectWinnerId = createSelector(selectRoomState, (s) => s.winnerId);
+export const selectLastUsername = createSelector(selectRoomState, (s) => s.lastUsername);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -9,6 +9,8 @@ export const selectJoined = createSelector(selectRoomState, (s) => s.joined);
 export const selectRoomError = createSelector(selectRoomState, (s) => s.error);
 export const selectChat = createSelector(selectRoomState, (s) => s.chat);
 export const selectGameStarted = createSelector(selectRoomState, (s) => s.gameStarted);
+export const selectGameFinished = createSelector(selectRoomState, (s) => s.gameFinished);
+export const selectWinnerId = createSelector(selectRoomState, (s) => s.winnerId);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();


### PR DESCRIPTION
## Summary
- Declare game winner when only one player remains and notify all clients
- Broadcast game over events through SignalR/MQTT and persist finished state
- Display win/lose modals on the frontend using new store actions and selectors

## Testing
- `dotnet build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7bdbb066c83309fd6d1db10cbc069