### PR TITLE
style: harmonize game map visuals

### DIFF
--- a/BattleTanks-Frontend/src/app/core/models/game.models.ts
+++ b/BattleTanks-Frontend/src/app/core/models/game.models.ts
@@ -10,6 +10,8 @@ export interface PlayerStateDto {
   hasShield: boolean;
   speed: number;
   isReady: boolean;
+  /** Hex colour used to render the player's tank */
+  color?: string;
 }
 
 export interface PlayerPositionDto {

--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.css
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.css
@@ -2,3 +2,38 @@
   display: block;
   width: 100%;
 }
+
+.pixel-canvas {
+  position: relative;
+  background: #0b1622;
+  border: 4px solid #1f3864;
+  box-shadow:
+    inset 0 0 0 2px #0b1822,
+    0 0 0 2px #18345c,
+    0 8px 0 0 #0b1822,
+    0 8px 20px rgba(0,0,0,0.5);
+  border-radius: 8px;
+}
+
+.pixel-canvas::after {
+  content: '';
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255,255,255,0.04) 0,
+    rgba(255,255,255,0.04) 1px,
+    transparent 2px,
+    transparent 4px
+  );
+  mix-blend-mode: overlay;
+  border-radius: inherit;
+}
+
+.pixel-canvas canvas {
+  display: block;
+  width: 100%;
+  border-radius: inherit;
+  image-rendering: pixelated;
+}

--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.html
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.html
@@ -1,6 +1,3 @@
-<div #wrap class="block w-full">
-  <canvas
-    #gameCanvas
-    class="w-full rounded-md border-2 border-blue-800 shadow-inner"
-  ></canvas>
+<div #wrap class="pixel-canvas">
+  <canvas #gameCanvas></canvas>
 </div>

--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -277,11 +277,11 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
     ctx.clearRect(0, 0, c.width, c.height);
 
     // Background
-    ctx.fillStyle = '#0b1e16';
+    ctx.fillStyle = '#0b1622';
     ctx.fillRect(0, 0, c.width, c.height);
 
     // Grid lines
-    ctx.strokeStyle = 'rgba(34, 211, 238, 0.06)';
+    ctx.strokeStyle = 'rgba(0, 170, 255, 0.06)';
     ctx.lineWidth = 1;
     for (let x = 0; x < c.width; x += 40) {
       ctx.beginPath();
@@ -316,10 +316,10 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
         let fill: string;
         switch (val) {
           case 1: // destructible brick
-            fill = '#b45309'; // amber‑600
+            fill = '#1e3a8a'; // blue‑800
             break;
           case 2: // indestructible wall
-            fill = '#4b5563'; // stone‑600
+            fill = '#334155'; // slate‑700
             break;
           case 3: // special base (treated like destructible for now)
             fill = '#dc2626'; // red‑600
@@ -347,7 +347,7 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
 
     // Bullets in bright cyan. Each bullet's position is derived from its
     // spawn position, direction and speed, along with the time since spawn.
-    ctx.fillStyle = '#22d3ee';
+    ctx.fillStyle = '#34a3ff';
     const now = Date.now();
     this.bullets().forEach(b => {
       if (!b.isActive) return;
@@ -456,9 +456,9 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
       ctx.rotate(p.rotation || 0);
 
       // Player body
-      ctx.fillStyle = isMe ? '#86e5f7' : '#22d3ee';
+      ctx.fillStyle = isMe ? '#8ac7f3' : '#3b82f6';
       ctx.fillRect(-12, -8, 24, 16);
-      ctx.fillStyle = isMe ? '#0ea5e9' : '#0284c7';
+      ctx.fillStyle = isMe ? '#34a3ff' : '#1e40af';
       ctx.fillRect(0, -2, 16, 4);
 
       ctx.restore();
@@ -466,9 +466,9 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
       // Player name label
       const label = isMe ? 'TÚ' : (p.username ?? 'Tank');
       const bgW   = Math.max(24, label.length * 7);
-      ctx.fillStyle = '#0b1e16';
+      ctx.fillStyle = '#0b1622';
       ctx.fillRect(p.x - 18, p.y - 22, bgW, 12);
-      ctx.fillStyle = '#a7f3d0';
+      ctx.fillStyle = '#c5def2';
       ctx.font = '10px monospace';
       ctx.fillText(label, p.x - 16, p.y - 12);
     });

--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -128,6 +128,14 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
     }
   });
 
+  private darken(hex: string): string {
+    const num = parseInt(hex.slice(1), 16);
+    const r = Math.max(0, ((num >> 16) & 0xff) - 40);
+    const g = Math.max(0, ((num >> 8) & 0xff) - 40);
+    const b = Math.max(0, (num & 0xff) - 40);
+    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
+  }
+
   ngAfterViewInit(): void {
     const canvas = this.canvasRef.nativeElement;
     this.ctx = canvas.getContext('2d');
@@ -456,9 +464,10 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
       ctx.rotate(p.rotation || 0);
 
       // Player body
-      ctx.fillStyle = isMe ? '#8ac7f3' : '#3b82f6';
+      const body = p.color ?? '#3b82f6';
+      ctx.fillStyle = body;
       ctx.fillRect(-12, -8, 24, 16);
-      ctx.fillStyle = isMe ? '#34a3ff' : '#1e40af';
+      ctx.fillStyle = this.darken(body);
       ctx.fillRect(0, -2, 16, 4);
 
       ctx.restore();

--- a/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -34,7 +34,8 @@
                 <h2 class="font-bold mb-1">Jugadores</h2>
                 <ul class="space-y-1">
                   @for (p of players(); track p.playerId) {
-                    <li>
+                    <li class="flex items-center">
+                      <span class="inline-block w-3 h-3 mr-1 rounded-sm" [style.background]="p.color"></span>
                       {{ p.username }} - Vidas: {{ p.lives }} - Puntos: {{ p.score }}
                       @if (!p.isAlive) {
                         <span class="text-red-400 ml-1">Game Over</span>
@@ -53,7 +54,10 @@
           <h2 class="font-bold mb-1">Jugadores</h2>
           <ul class="space-y-1">
             @for (p of players(); track p.playerId) {
-              <li>{{ p.username }} - {{ p.isReady ? 'Listo' : 'Esperando' }}</li>
+              <li class="flex items-center">
+                <span class="inline-block w-3 h-3 mr-1 rounded-sm" [style.background]="p.color"></span>
+                {{ p.username }} - {{ p.isReady ? 'Listo' : 'Esperando' }}
+              </li>
             }
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- wrap room canvas with a pixel-styled container and scanline overlay
- recolor map background, grid, tiles, bullets, and player sprites to match UI palette

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b92056d3648330ad3e4e4d7f837b01