### PR TITLE
Fix winner detection when room creator joins first

### DIFF
--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Bullets.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Bullets.cs
@@ -235,7 +235,7 @@ public partial class GameHub : Hub
             var connId = _tracker.GetConnectionIdByUserId(kv.Key);
             if (connId != null)
             {
-                var didWin = kv.Value > 0;
+                bool? didWin = winnerId == null ? (bool?)null : kv.Key == winnerId;
                 await Clients.Client(connId).SendAsync("matchResult", didWin);
             }
         }

--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
@@ -69,13 +69,11 @@ public partial class GameHub : Hub
         await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
         _tracker.Set(Context.ConnectionId, (await _rooms.GetByCodeAsync(roomCode))!.RoomId, roomCode, userId, uname);
 
-        if (!_playerLivesByRoom.ContainsKey(roomCode))
-            _playerLivesByRoom[roomCode] = new();
-        _playerLivesByRoom[roomCode][userId] = 3;
+        var livesDict = _playerLivesByRoom.GetOrAdd(roomCode, _ => new());
+        livesDict[userId] = 3;
 
-        if (!_playerScoresByRoom.ContainsKey(roomCode))
-            _playerScoresByRoom[roomCode] = new();
-        _playerScoresByRoom[roomCode][userId] = 0;
+        var scoresDict = _playerScoresByRoom.GetOrAdd(roomCode, _ => new());
+        scoresDict[userId] = 0;
 
         await Clients.Group(roomCode).SendAsync("playerJoined", new { userId, username = uname });
         // Publish join event via MQTT and record in history

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -35,7 +35,7 @@ export class SignalRService {
   readonly playerReady$ = new Subject<{ userId: string; ready: boolean }>();
   readonly gameStarted$ = new Subject<void>();
   readonly gameFinished$ = new Subject<string | null>();
-  readonly matchResult$ = new Subject<boolean>();
+  readonly matchResult$ = new Subject<boolean | null>();
 
   get isConnected() {
     return !!this.hub && this.hub.state === 'Connected';
@@ -117,7 +117,7 @@ export class SignalRService {
       this.gameFinished$.next(winnerId);
     });
 
-    this.hub.on('matchResult', (didWin: boolean) => {
+    this.hub.on('matchResult', (didWin: boolean | null) => {
       console.log('[SignalR] matchResult:', didWin);
       this.matchResult$.next(didWin);
     });

--- a/BattleTanks-Frontend/src/app/features/room/room.component.html
+++ b/BattleTanks-Frontend/src/app/features/room/room.component.html
@@ -17,7 +17,19 @@
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 relative">
             @if (gameFinished()) {
               <div class="absolute inset-0 z-10 flex flex-col items-center justify-center bg-black/80 text-yellow-300 rounded-md px-4 py-8 space-y-3">
-                <h2 class="text-lg">{{ winnerId() ? (didWin() ? '¡Ganaste!' : '¡Has perdido!') : '¡Empate!' }}</h2>
+                <h2 class="text-lg">
+                  {{
+                    winnerId() === null
+                      ? '¡Empate!'
+                      : didWin() === true
+                        ? '¡Ganaste!'
+                        : didWin() === false
+                          ? '¡Has perdido!'
+                          : winnerId() === myPlayer()?.playerId
+                            ? '¡Ganaste!'
+                            : '¡Has perdido!'
+                  }}
+                </h2>
                 <a routerLink="/lobby" class="pixel-btn text-xs">Volver al lobby</a>
               </div>
             }

--- a/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -38,7 +38,7 @@ export const roomActions = createActionGroup({
     'Player Ready': props<{ userId: string; ready: boolean }>(),
     'Game Started': emptyProps(),
     'Game Finished': props<{ winnerId: string | null }>(),
-    'Match Result': props<{ didWin: boolean }>(),
+    'Match Result': props<{ didWin: boolean | null }>(),
 
     // Cliente→servidor
     'Send Message': props<{ content: string }>(),

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -21,7 +21,7 @@ class SignalRServiceMock {
   reconnected$ = new Subject<void>();
   disconnected$ = new Subject<void>();
   gameFinished$ = new Subject<string | null>();
-  matchResult$ = new Subject<boolean>();
+  matchResult$ = new Subject<boolean | null>();
 
   connect = jasmine.createSpy('connect').and.returnValue(Promise.resolve());
   disconnect = jasmine.createSpy('disconnect').and.returnValue(Promise.resolve());

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -22,6 +22,7 @@ class SignalRServiceMock {
   disconnected$ = new Subject<void>();
   gameFinished$ = new Subject<string | null>();
   matchResult$ = new Subject<boolean | null>();
+  matchResults$ = new Subject<any>();
 
   connect = jasmine.createSpy('connect').and.returnValue(Promise.resolve());
   disconnect = jasmine.createSpy('disconnect').and.returnValue(Promise.resolve());

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.spec.ts
@@ -7,8 +7,8 @@ describe('Room Selectors', () => {
 
   beforeEach(() => {
       const players = roomPlayersAdapter.setAll([
-        { playerId: 'p1', username: 'juan', x: 1, y: 2, rotation: 0, lives: 3, isAlive: true, score: 0 },
-        { playerId: 'p2', username: 'sebas', x: 4, y: 5, rotation: 0, lives: 3, isAlive: true, score: 0 },
+        { playerId: 'p1', username: 'juan', x: 1, y: 2, rotation: 0, lives: 3, isAlive: true, score: 0, hasShield: false, speed: 200, isReady: false },
+        { playerId: 'p2', username: 'sebas', x: 4, y: 5, rotation: 0, lives: 3, isAlive: true, score: 0, hasShield: false, speed: 200, isReady: false },
       ], roomPlayersAdapter.getInitialState());
 
     const bullets = roomBulletsAdapter.setAll([


### PR DESCRIPTION
## Summary
- use thread-safe player life tracking on join
- send per-player match results based on winner and allow draws
- expose nullable `matchResult` on Angular client and adjust tests

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2f6a1bc88330b7e909cdbe820961