### PR TITLE
Fix match result handling for room creator

### DIFF
--- a/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
+++ b/BattleTanks-Backend/Infrastructure/SignalR/Hubs/GameHub.Players.cs
@@ -69,6 +69,8 @@ public partial class GameHub : Hub
         await Groups.AddToGroupAsync(Context.ConnectionId, roomCode);
         _tracker.Set(Context.ConnectionId, (await _rooms.GetByCodeAsync(roomCode))!.RoomId, roomCode, userId, uname);
 
+        await Clients.Caller.SendAsync("identity", new { userId, username = uname });
+
         if (!_playerLivesByRoom.ContainsKey(roomCode))
             _playerLivesByRoom[roomCode] = new();
         _playerLivesByRoom[roomCode][userId] = 3;

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -35,7 +35,10 @@ export class SignalRService {
   readonly playerReady$ = new Subject<{ userId: string; ready: boolean }>();
   readonly gameStarted$ = new Subject<void>();
   readonly gameFinished$ = new Subject<string | null>();
-  readonly matchResult$ = new Subject<boolean>();
+  // Emits the playerId and whether that player won.  Broadcasting the
+  // player id allows clients to filter the result locally, ensuring the
+  // creator also receives their correct outcome.
+  readonly matchResult$ = new Subject<{ playerId: string; didWin: boolean }>();
 
   get isConnected() {
     return !!this.hub && this.hub.state === 'Connected';
@@ -117,9 +120,9 @@ export class SignalRService {
       this.gameFinished$.next(winnerId);
     });
 
-    this.hub.on('matchResult', (didWin: boolean) => {
-      console.log('[SignalR] matchResult:', didWin);
-      this.matchResult$.next(didWin);
+    this.hub.on('matchResult', (playerId: string, didWin: boolean) => {
+      console.log('[SignalR] matchResult:', playerId, didWin);
+      this.matchResult$.next({ playerId, didWin });
     });
 
     this.hub.on('mapState', (map: any[]) => {

--- a/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
+++ b/BattleTanks-Frontend/src/app/core/services/signalr.service.ts
@@ -17,6 +17,7 @@ export class SignalRService {
   private hub: HubConnection | null = null;
   private manualDisconnect = false;
 
+  readonly identity$ = new Subject<{ userId: string; username: string }>();
   readonly playerJoined$ = new Subject<{ userId: string; username: string }>();
   readonly playerLeft$ = new Subject<string>();
   readonly chatMessage$ = new Subject<ChatMessageDto>();
@@ -65,6 +66,11 @@ export class SignalRService {
       .build();
 
     // Event handlers
+    this.hub.on('identity', (payload: { userId: string; username: string }) => {
+      console.log('[SignalR] identity:', payload);
+      this.identity$.next(payload);
+    });
+
     this.hub.on('playerJoined', (payload) => {
       console.log('[SignalR] playerJoined:', payload);
       this.playerJoined$.next(payload);

--- a/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.actions.ts
@@ -27,6 +27,7 @@ export const roomActions = createActionGroup({
     'Roster Loaded': props<{ players: PlayerStateDto[] }>(),
 
     // Server→cliente
+    'Identity Received': props<{ userId: string }>(),
     'Player Joined': props<{ userId: string; username: string }>(),
     'Player Left': props<{ userId: string }>(),
     'Player Moved': props<{ player: PlayerStateDto | { playerId: string; x: number; y: number; rotation: number } }>(),

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.spec.ts
@@ -21,7 +21,7 @@ class SignalRServiceMock {
   reconnected$ = new Subject<void>();
   disconnected$ = new Subject<void>();
   gameFinished$ = new Subject<string | null>();
-  matchResult$ = new Subject<boolean>();
+  matchResult$ = new Subject<{ playerId: string; didWin: boolean }>();
 
   connect = jasmine.createSpy('connect').and.returnValue(Promise.resolve());
   disconnect = jasmine.createSpy('disconnect').and.returnValue(Promise.resolve());

--- a/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.effects.ts
@@ -5,7 +5,7 @@ import { SignalRService } from '../../../core/services/signalr.service';
 import { MqttService } from '../../../core/services/mqtt.service';
 import { catchError, filter, from, map, merge, mergeMap, of, switchMap, takeUntil, tap, throttleTime, withLatestFrom } from 'rxjs';
 import { Store } from '@ngrx/store';
-import { selectRoomCode, selectGameFinished, selectPlayers, selectLastUsername } from './room.selectors';
+import { selectRoomCode, selectGameFinished, selectMyId } from './room.selectors';
 import { selectUser } from '../../auth/store/auth.selectors';
 import { RoomService } from '../../../core/services/room.service'; 
 import { RoomStateDto } from '../../../core/models/room.models';
@@ -38,6 +38,7 @@ events$ = createEffect(() =>
       const stop$ = this.actions$.pipe(ofType(roomActions.hubDisconnected, roomActions.left));
       return merge(
         // SignalR events
+        this.hub.identity$.pipe(map((p) => roomActions.identityReceived({ userId: p.userId }))),
         this.hub.playerJoined$.pipe(map((p) => roomActions.playerJoined(p))),
         this.hub.playerLeft$.pipe(map((userId) => roomActions.playerLeft({ userId }))),
         this.hub.chatMessage$.pipe(map((msg) => roomActions.messageReceived({ msg }))),
@@ -49,20 +50,8 @@ events$ = createEffect(() =>
         this.hub.playerReady$.pipe(map((p) => roomActions.playerReady(p))),
         this.hub.gameStarted$.pipe(map(() => roomActions.gameStarted())),
         this.hub.gameFinished$.pipe(
-          withLatestFrom(
-            this.store.select(selectUser),
-            this.store.select(selectPlayers),
-            this.store.select(selectLastUsername)
-          ),
-          mergeMap(([winnerId, user, players, last]) => {
-            let myId = user?.id;
-            if (!myId) {
-              const lname = last?.toLowerCase() ?? '';
-              const me = players.find(
-                (p) => (p.username?.toLowerCase() ?? '') === lname
-              );
-              myId = me?.playerId;
-            }
+          withLatestFrom(this.store.select(selectMyId)),
+          mergeMap(([winnerId, myId]) => {
             const didWin = !!winnerId && winnerId === myId;
             return [
               roomActions.gameFinished({ winnerId }),
@@ -71,22 +60,8 @@ events$ = createEffect(() =>
           })
         ),
         this.hub.matchResult$.pipe(
-          withLatestFrom(
-            this.store.select(selectUser),
-            this.store.select(selectPlayers),
-            this.store.select(selectLastUsername)
-          ),
-          filter(([evt, user, players, last]) => {
-            let myId = user?.id;
-            if (!myId) {
-              const lname = last?.toLowerCase() ?? '';
-              const me = players.find(
-                (p) => (p.username?.toLowerCase() ?? '') === lname
-              );
-              myId = me?.playerId;
-            }
-            return evt.playerId === myId;
-          }),
+          withLatestFrom(this.store.select(selectMyId)),
+          filter(([evt, myId]) => evt.playerId === myId),
           map(([evt]) => roomActions.matchResult({ didWin: evt.didWin }))
         ),
         // MQTT events
@@ -99,20 +74,8 @@ events$ = createEffect(() =>
         this.mqtt.playerHit$.pipe(map((dto) => roomActions.playerHit({ dto }))),
         this.mqtt.playerDied$.pipe(map((playerId) => roomActions.playerDied({ playerId }))),
         this.mqtt.gameFinished$.pipe(
-          withLatestFrom(
-            this.store.select(selectUser),
-            this.store.select(selectPlayers),
-            this.store.select(selectLastUsername)
-          ),
-          mergeMap(([winnerId, user, players, last]) => {
-            let myId = user?.id;
-            if (!myId) {
-              const lname = last?.toLowerCase() ?? '';
-              const me = players.find(
-                (p) => (p.username?.toLowerCase() ?? '') === lname
-              );
-              myId = me?.playerId;
-            }
+          withLatestFrom(this.store.select(selectMyId)),
+          mergeMap(([winnerId, myId]) => {
             const didWin = !!winnerId && winnerId === myId;
             return [
               roomActions.gameFinished({ winnerId }),

--- a/BattleTanks-Frontend/src/app/features/room/store/room.reducer.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.reducer.ts
@@ -11,6 +11,7 @@ export interface RoomState {
   joined: boolean;
   hubConnected: boolean;
   error: string | null;
+  myId: string | null;
   players: EntityState<PlayerEntity>;
   bullets: EntityState<BulletEntity>;
   chat: ChatMessageDto[];
@@ -51,6 +52,7 @@ const initialState: RoomState = {
   joined: false,
   hubConnected: false,
   error: null,
+  myId: null,
   players: playersAdapter.getInitialState(),
   bullets: bulletsAdapter.getInitialState(),
   chat: [],
@@ -78,6 +80,7 @@ export const roomReducer = createReducer(
     ...s,
     joined: false,
     roomCode: null,
+    myId: null,
     players: playersAdapter.removeAll(s.players),
     bullets: bulletsAdapter.removeAll(s.bullets),
     chat: [],
@@ -108,6 +111,8 @@ export const roomReducer = createReducer(
     playersState = recolor(playersState);
     return { ...s, players: playersState };
   }),
+
+  on(roomActions.identityReceived, (s, { userId }) => ({ ...s, myId: userId })),
 
   on(roomActions.playerLeft, (s, { userId }) => {
     let playersState = playersAdapter.removeOne(userId, s.players);

--- a/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
+++ b/BattleTanks-Frontend/src/app/features/room/store/room.selectors.ts
@@ -13,6 +13,7 @@ export const selectGameFinished = createSelector(selectRoomState, (s) => s.gameF
 export const selectWinnerId = createSelector(selectRoomState, (s) => s.winnerId);
 export const selectDidWin = createSelector(selectRoomState, (s) => s.didWin);
 export const selectLastUsername = createSelector(selectRoomState, (s) => s.lastUsername);
+export const selectMyId = createSelector(selectRoomState, (s) => s.myId);
 
 const playersSelectors = roomPlayersAdapter.getSelectors();
 const bulletsSelectors = roomBulletsAdapter.getSelectors();


### PR DESCRIPTION
## Summary
- broadcast per-player match results including playerId from backend
- update SignalR client to receive player-specific results
- derive winner on game finish and filter results per player so room creator sees correct outcome

## Testing
- `dotnet build BattleTanks-Backend.sln` *(fails: command not found)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba4cdebe8083309e5e450afd6407e2