### PR TITLE
Add multi-player load test scenario

### DIFF
--- a/load-tests/package.json
+++ b/load-tests/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "auth.test.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "multi-player": "node scenarios/multi-player.js"
   },
   "keywords": [],
   "author": "",

--- a/load-tests/scenarios/createRoom.js
+++ b/load-tests/scenarios/createRoom.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 
 async function createRoom(apiUrl, token, name, maxPlayers = 4, isPublic = true, creatorName = null) {
+  const start = Date.now();
   const res = await fetch(`${apiUrl}/api/v1/Rooms`, {
     method: 'POST',
     headers: {
@@ -15,6 +16,8 @@ async function createRoom(apiUrl, token, name, maxPlayers = 4, isPublic = true, 
     throw new Error('Failed to create room: ' + JSON.stringify(data));
   }
 
+  const code = data.roomCode || data.RoomCode;
+  console.log(`Room ${code} created in ${Date.now() - start} ms`);
   return data; // Expected to contain roomId and roomCode
 }
 

--- a/load-tests/scenarios/createRoom.js
+++ b/load-tests/scenarios/createRoom.js
@@ -1,0 +1,21 @@
+const fetch = require('node-fetch');
+
+async function createRoom(apiUrl, token, name, maxPlayers = 4, isPublic = true, creatorName = null) {
+  const res = await fetch(`${apiUrl}/api/v1/Rooms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`
+    },
+    body: JSON.stringify({ name, maxPlayers, isPublic, creatorName })
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error('Failed to create room: ' + JSON.stringify(data));
+  }
+
+  return data; // Expected to contain roomId and roomCode
+}
+
+module.exports = { createRoom };

--- a/load-tests/scenarios/login.js
+++ b/load-tests/scenarios/login.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 
 async function loginUser(apiUrl, usernameOrEmail, password) {
+  const start = Date.now();
   const res = await fetch(`${apiUrl}/api/v1/Auth/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -14,7 +15,9 @@ async function loginUser(apiUrl, usernameOrEmail, password) {
 
   const setCookie = res.headers.get('set-cookie');
   if (setCookie) {
-    return setCookie.split(';')[0].split('=')[1];
+    const token = setCookie.split(';')[0].split('=')[1];
+    console.log(`Logged in ${usernameOrEmail} in ${Date.now() - start} ms`);
+    return token;
   }
 
   const data = await res.json();

--- a/load-tests/scenarios/login.js
+++ b/load-tests/scenarios/login.js
@@ -1,0 +1,24 @@
+const fetch = require('node-fetch');
+
+async function loginUser(apiUrl, usernameOrEmail, password) {
+  const res = await fetch(`${apiUrl}/api/v1/Auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ usernameOrEmail, password })
+  });
+
+  if (!res.ok) {
+    const data = await res.text();
+    throw new Error(`Failed to login ${usernameOrEmail}: ${res.status} ${data}`);
+  }
+
+  const setCookie = res.headers.get('set-cookie');
+  if (setCookie) {
+    return setCookie.split(';')[0].split('=')[1];
+  }
+
+  const data = await res.json();
+  throw new Error('No token found. Response: ' + JSON.stringify(data));
+}
+
+module.exports = { loginUser };

--- a/load-tests/scenarios/multi-player.js
+++ b/load-tests/scenarios/multi-player.js
@@ -1,0 +1,42 @@
+const { registerUser } = require('./register');
+const { loginUser } = require('./login');
+const { createRoom } = require('./createRoom');
+const { play } = require('./play');
+const { InfluxDB } = require('@influxdata/influxdb-client');
+
+async function runScenario() {
+  const API_URL = process.env.API_URL || 'http://localhost:5284';
+  const SIGNALR_URL = process.env.SIGNALR_URL || 'http://localhost:5284/game-hub';
+  const INFLUX_URL = process.env.INFLUX_URL || 'http://localhost:8086';
+  const INFLUX_TOKEN = process.env.INFLUX_TOKEN || 'battletanks-token';
+  const INFLUX_ORG = process.env.INFLUX_ORG || 'battletanks';
+  const INFLUX_BUCKET = process.env.INFLUX_BUCKET || 'k6';
+
+  const influx = new InfluxDB({ url: INFLUX_URL, token: INFLUX_TOKEN });
+  const writeApi = influx.getWriteApi(INFLUX_ORG, INFLUX_BUCKET);
+
+  const user1 = `player_${Date.now()}`;
+  const user2 = `${user1}_b`;
+
+  await registerUser(API_URL, user1, `${user1}@test.com`, 'password');
+  await registerUser(API_URL, user2, `${user2}@test.com`, 'password');
+
+  const token1 = await loginUser(API_URL, user1, 'password');
+  const token2 = await loginUser(API_URL, user2, 'password');
+
+  const room = await createRoom(API_URL, token1, 'loadtest-room', 4, true, user1);
+  const roomCode = room.roomCode || room.RoomCode;
+
+  await Promise.all([
+    play(SIGNALR_URL, token1, roomCode, user1, writeApi),
+    play(SIGNALR_URL, token2, roomCode, user2, writeApi)
+  ]);
+
+  await writeApi.close();
+  console.log('Scenario completed');
+}
+
+runScenario().catch(err => {
+  console.error('Scenario failed:', err);
+  process.exit(1);
+});

--- a/load-tests/scenarios/play.js
+++ b/load-tests/scenarios/play.js
@@ -7,31 +7,57 @@ async function play(signalrUrl, token, roomCode, username, writeApi) {
     .configureLogging(signalR.LogLevel.None)
     .build();
 
-  const start = Date.now();
+  const metrics = { username, connect: 0, join: 0, chat: 0, moves: [], total: 0 };
+
+  const connectStart = Date.now();
   await connection.start();
+  metrics.connect = Date.now() - connectStart;
 
+  const joinStart = Date.now();
   await connection.invoke('JoinRoom', roomCode, username, null);
-  await connection.invoke('SendChat', `Hello from ${username}`);
-  await connection.invoke('UpdatePosition', {
-    userId: username,
-    x: 1,
-    y: 1,
-    rotation: 0,
-    timestamp: Date.now()
-  });
+  metrics.join = Date.now() - joinStart;
 
-  const latency = Date.now() - start;
-  console.log(`${username} -> Latency: ${latency} ms`);
+  const chatStart = Date.now();
+  await connection.invoke('SendChat', `Hello from ${username}`);
+  metrics.chat = Date.now() - chatStart;
+
+  for (let i = 0; i < 5; i++) {
+    const moveStart = Date.now();
+    await connection.invoke('UpdatePosition', {
+      userId: username,
+      x: i + 1,
+      y: i + 1,
+      rotation: (i * 90) % 360,
+      timestamp: Date.now()
+    });
+    const moveLatency = Date.now() - moveStart;
+    metrics.moves.push(moveLatency);
+    console.log(`${username} -> Move ${i + 1} latency: ${moveLatency} ms`);
+
+    if (writeApi) {
+      const movePoint = new Point('signalr_move')
+        .tag('client', username)
+        .intField('move', i + 1)
+        .intField('latency', moveLatency);
+      writeApi.writePoint(movePoint);
+    }
+  }
+
+  metrics.total = metrics.connect + metrics.join + metrics.chat + metrics.moves.reduce((a, b) => a + b, 0);
+  console.log(`${username} metrics:`, metrics);
 
   if (writeApi) {
     const point = new Point('signalr')
       .tag('client', username)
-      .intField('latency', latency);
+      .intField('connect', metrics.connect)
+      .intField('join', metrics.join)
+      .intField('chat', metrics.chat)
+      .intField('total', metrics.total);
     writeApi.writePoint(point);
   }
 
   await connection.stop();
-  return latency;
+  return metrics;
 }
 
 module.exports = { play };

--- a/load-tests/scenarios/play.js
+++ b/load-tests/scenarios/play.js
@@ -1,0 +1,37 @@
+const signalR = require('@microsoft/signalr');
+const { Point } = require('@influxdata/influxdb-client');
+
+async function play(signalrUrl, token, roomCode, username, writeApi) {
+  const connection = new signalR.HubConnectionBuilder()
+    .withUrl(`${signalrUrl}?access_token=${token}`)
+    .configureLogging(signalR.LogLevel.None)
+    .build();
+
+  const start = Date.now();
+  await connection.start();
+
+  await connection.invoke('JoinRoom', roomCode, username, null);
+  await connection.invoke('SendChat', `Hello from ${username}`);
+  await connection.invoke('UpdatePosition', {
+    userId: username,
+    x: 1,
+    y: 1,
+    rotation: 0,
+    timestamp: Date.now()
+  });
+
+  const latency = Date.now() - start;
+  console.log(`${username} -> Latency: ${latency} ms`);
+
+  if (writeApi) {
+    const point = new Point('signalr')
+      .tag('client', username)
+      .intField('latency', latency);
+    writeApi.writePoint(point);
+  }
+
+  await connection.stop();
+  return latency;
+}
+
+module.exports = { play };

--- a/load-tests/scenarios/register.js
+++ b/load-tests/scenarios/register.js
@@ -1,6 +1,7 @@
 const fetch = require('node-fetch');
 
 async function registerUser(apiUrl, username, email, password) {
+  const start = Date.now();
   const res = await fetch(`${apiUrl}/api/v1/Auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -12,7 +13,9 @@ async function registerUser(apiUrl, username, email, password) {
     throw new Error(`Failed to register ${username}: ${res.status} ${data}`);
   }
 
-  return res.json();
+  const data = await res.json();
+  console.log(`Registered ${username} in ${Date.now() - start} ms`);
+  return data;
 }
 
 module.exports = { registerUser };

--- a/load-tests/scenarios/register.js
+++ b/load-tests/scenarios/register.js
@@ -4,7 +4,7 @@ async function registerUser(apiUrl, username, email, password) {
   const res = await fetch(`${apiUrl}/api/v1/Auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, email, password })
+    body: JSON.stringify({ username, email, password, ConfirmPassword: password })
   });
 
   if (!res.ok) {

--- a/load-tests/scenarios/register.js
+++ b/load-tests/scenarios/register.js
@@ -1,0 +1,18 @@
+const fetch = require('node-fetch');
+
+async function registerUser(apiUrl, username, email, password) {
+  const res = await fetch(`${apiUrl}/api/v1/Auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, email, password })
+  });
+
+  if (!res.ok) {
+    const data = await res.text();
+    throw new Error(`Failed to register ${username}: ${res.status} ${data}`);
+  }
+
+  return res.json();
+}
+
+module.exports = { registerUser };


### PR DESCRIPTION
## Summary
- orchestrate registration, login, room creation and gameplay for two users
- allow running the scenario via `npm run multi-player`

## Testing
- `node --check load-tests/scenarios/register.js load-tests/scenarios/login.js load-tests/scenarios/createRoom.js load-tests/scenarios/play.js load-tests/scenarios/multi-player.js`
- `npm run multi-player` *(fails: ECONNREFUSED to http://localhost:5284)*

------
https://chatgpt.com/codex/tasks/task_e_68ba71570e348330ae87e2a2081a8895