### PR TITLE
Remove LastLoginAt field and related logic

### DIFF
--- a/BattleTanks-Backend/Application/Services/AuthService.cs
+++ b/BattleTanks-Backend/Application/Services/AuthService.cs
@@ -45,9 +45,6 @@ public class AuthService : IAuthService
         if (!BCrypt.Net.BCrypt.Verify(loginDto.Password, user.PasswordHash))
             throw new UnauthorizedAccessException("Invalid credentials");
 
-        user.UpdateLastLogin();
-        await _userRepository.UpdateAsync(user);
-
         return user;
     }
 

--- a/BattleTanks-Backend/Domain/Entities/User.cs
+++ b/BattleTanks-Backend/Domain/Entities/User.cs
@@ -7,7 +7,6 @@ public class User
     public string Email { get; private set; }
     public string PasswordHash { get; private set; }
     public DateTime CreatedAt { get; private set; }
-    public DateTime LastLoginAt { get; private set; }
     
     public int GamesPlayed { get; private set; }
     public int GamesWon { get; private set; }
@@ -27,16 +26,10 @@ public class User
             Email = email.ToLowerInvariant(),
             PasswordHash = passwordHash,
             CreatedAt = DateTime.UtcNow,
-            LastLoginAt = DateTime.UtcNow,
             GamesPlayed = 0,
             GamesWon = 0,
             TotalScore = 0
         };
-    }
-    
-    public void UpdateLastLogin()
-    {
-        LastLoginAt = DateTime.UtcNow;
     }
     
     public void AddGameResult(bool won, int score)

--- a/BattleTanks-Backend/Infrastructure/Migrations/20250803211226_InitialMigration.cs
+++ b/BattleTanks-Backend/Infrastructure/Migrations/20250803211226_InitialMigration.cs
@@ -55,7 +55,6 @@ namespace Infrastructure.Migrations
                     Email = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
                     PasswordHash = table.Column<string>(type: "text", nullable: false),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    LastLoginAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     GamesPlayed = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
                     GamesWon = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
                     TotalScore = table.Column<int>(type: "integer", nullable: false, defaultValue: 0)

--- a/BattleTanks-Backend/Infrastructure/Migrations/20250903004734_AddIsReadyToPlayer.cs
+++ b/BattleTanks-Backend/Infrastructure/Migrations/20250903004734_AddIsReadyToPlayer.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsReadyToPlayer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsReady",
+                table: "players",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsReady",
+                table: "players");
+        }
+    }
+}

--- a/BattleTanks-Backend/Infrastructure/Migrations/20250906062119_RemoveLastLoginAt.cs
+++ b/BattleTanks-Backend/Infrastructure/Migrations/20250906062119_RemoveLastLoginAt.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveLastLoginAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastLoginAt",
+                table: "users");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastLoginAt",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}

--- a/BattleTanks-Backend/Infrastructure/Migrations/BattleTanksDbContextModelSnapshot.cs
+++ b/BattleTanks-Backend/Infrastructure/Migrations/BattleTanksDbContextModelSnapshot.cs
@@ -241,9 +241,6 @@ namespace Infrastructure.Migrations
                         .HasColumnType("integer")
                         .HasDefaultValue(0);
 
-                    b.Property<DateTime>("LastLoginAt")
-                        .HasColumnType("timestamp with time zone");
-
                     b.Property<string>("PasswordHash")
                         .IsRequired()
                         .HasColumnType("text");


### PR DESCRIPTION
## Summary
- drop LastLoginAt from User entity and database schema
- simplify login flow so it no longer updates the user record

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68bbc95618d8833083d36a3389b94e90