### PR TITLE
feat: profile backend and add caching

### DIFF
--- a/BattleTanks-Backend/BattleTanks-Backend/BattleTanks-Backend.csproj
+++ b/BattleTanks-Backend/BattleTanks-Backend/BattleTanks-Backend.csproj
@@ -9,12 +9,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.18" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
+        <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.5.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+        <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.5.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/BattleTanks-Backend/BattleTanks-Backend/Program.cs
+++ b/BattleTanks-Backend/BattleTanks-Backend/Program.cs
@@ -8,6 +8,8 @@ using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Profiling;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -22,6 +24,11 @@ builder.Services.AddControllers(options =>
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+Microsoft.Extensions.DependencyInjection.MvcExtensions.AddMiniProfiler(builder.Services, options =>
+{
+    options.RouteBasePath = "/profiler";
+}).AddEntityFramework();
 
 // JWT options
 builder.Services.Configure<JwtOptions>(builder.Configuration.GetSection(JwtOptions.SectionName));
@@ -123,6 +130,7 @@ app.UseRouting();
 app.UseCors("FrontDev");
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseMiniProfiler();
 
 app.UseEndpoints(endpoints =>
 {

--- a/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/BattleTanks-Backend/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,12 +1,11 @@
 using Application.Interfaces;
 using Application.Services;
-using Infrastructure.Interfaces;
 using Infrastructure.Persistence;
 using Infrastructure.Persistence.Repositories;
 using Infrastructure.Services;
+using Infrastructure.Interfaces;
 using Infrastructure.SignalR.Abstractions;
 using Infrastructure.SignalR.Services;
-using Infrastructure.Interfaces;
 using Infrastructure.Configuration;
 using StackExchange.Redis;
 using Microsoft.EntityFrameworkCore;
@@ -26,6 +25,18 @@ public static class ServiceCollectionExtensions
         // Obtener la cadena de conexión de Redis (si está configurada) antes de registrar los servicios
         var redisConnectionString = configuration.GetConnectionString("Redis")
             ?? configuration.GetSection("RedisOptions").GetValue<string>("ConnectionString");
+
+        if (!string.IsNullOrEmpty(redisConnectionString))
+        {
+            services.AddStackExchangeRedisCache(options =>
+            {
+                options.Configuration = redisConnectionString;
+            });
+        }
+        else
+        {
+            services.AddDistributedMemoryCache();
+        }
 
         services.AddScoped<IUserRepository, EfUserRepository>();
         services.AddScoped<IPlayerRepository, EfPlayerRepository>();

--- a/BattleTanks-Backend/Infrastructure/Infrastructure.csproj
+++ b/BattleTanks-Backend/Infrastructure/Infrastructure.csproj
@@ -22,8 +22,9 @@
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.8" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.13.0" />
-	  <PackageReference Include="MQTTnet" Version="4.1.0.247" />
-	  <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+          <PackageReference Include="MQTTnet" Version="4.1.0.247" />
+          <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
     <PackageReference Include="EFCore.BulkExtensions" Version="8.0.3" />
   </ItemGroup>
 

--- a/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfPlayerRepository.cs
+++ b/BattleTanks-Backend/Infrastructure/Persistence/Repositories/EfPlayerRepository.cs
@@ -1,34 +1,80 @@
 using Application.Interfaces;
 using Domain.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Infrastructure.Persistence.Repositories;
 
 public class EfPlayerRepository : IPlayerRepository
 {
     private readonly BattleTanksDbContext _context;
+    private readonly IDistributedCache _cache;
 
-    public EfPlayerRepository(BattleTanksDbContext context)
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private const string CacheById = "player:id:";
+    private const string CacheByUser = "player:user:";
+
+    private static readonly Func<BattleTanksDbContext, Guid, Task<Player?>> _getByIdQuery =
+        EF.CompileAsyncQuery((BattleTanksDbContext ctx, Guid id) =>
+            ctx.Players.AsNoTracking()
+               .Include(p => p.User)
+               .Include(p => p.GameSession)
+               .FirstOrDefault(p => p.Id == id));
+
+    private static readonly Func<BattleTanksDbContext, Guid, Task<Player?>> _getByUserIdQuery =
+        EF.CompileAsyncQuery((BattleTanksDbContext ctx, Guid userId) =>
+            ctx.Players.AsNoTracking()
+               .Include(p => p.User)
+               .Include(p => p.GameSession)
+               .FirstOrDefault(p => p.UserId == userId));
+
+    public EfPlayerRepository(BattleTanksDbContext context, IDistributedCache cache)
     {
         _context = context;
+        _cache = cache;
     }
 
     public async Task<Player?> GetByIdAsync(Guid id)
     {
-        return await _context.Players
-            .AsNoTracking()
-            .Include(p => p.User)
-            .Include(p => p.GameSession)
-            .FirstOrDefaultAsync(p => p.Id == id);
+        var cacheKey = CacheById + id;
+        var cached = await _cache.GetStringAsync(cacheKey);
+        if (cached is not null)
+            return JsonSerializer.Deserialize<Player>(cached, _jsonOptions);
+
+        var player = await _getByIdQuery(_context, id);
+        if (player != null)
+        {
+            await _cache.SetStringAsync(cacheKey, JsonSerializer.Serialize(player, _jsonOptions),
+                new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(5) });
+            await _cache.SetStringAsync(CacheByUser + player.UserId, JsonSerializer.Serialize(player, _jsonOptions),
+                new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(5) });
+        }
+        return player;
     }
 
     public async Task<Player?> GetByUserIdAsync(Guid userId)
     {
-        return await _context.Players
-            .AsNoTracking()
-            .Include(p => p.User)
-            .Include(p => p.GameSession)
-            .FirstOrDefaultAsync(p => p.UserId == userId);
+        var cacheKey = CacheByUser + userId;
+        var cached = await _cache.GetStringAsync(cacheKey);
+        if (cached is not null)
+            return JsonSerializer.Deserialize<Player>(cached, _jsonOptions);
+
+        var player = await _getByUserIdQuery(_context, userId);
+        if (player != null)
+        {
+            await _cache.SetStringAsync(cacheKey, JsonSerializer.Serialize(player, _jsonOptions),
+                new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(5) });
+            await _cache.SetStringAsync(CacheById + player.Id, JsonSerializer.Serialize(player, _jsonOptions),
+                new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(5) });
+        }
+        return player;
     }
 
     public async Task<Player?> GetByConnectionIdAsync(string connectionId)
@@ -62,12 +108,16 @@ public class EfPlayerRepository : IPlayerRepository
     {
         await _context.Players.AddAsync(player);
         await _context.SaveChangesAsync();
+        await _cache.RemoveAsync(CacheByUser + player.UserId);
+        await _cache.RemoveAsync(CacheById + player.Id);
     }
 
     public async Task UpdateAsync(Player player)
     {
         _context.Players.Update(player);
         await _context.SaveChangesAsync();
+        await _cache.RemoveAsync(CacheByUser + player.UserId);
+        await _cache.RemoveAsync(CacheById + player.Id);
     }
 
     public async Task DeleteAsync(Guid id)
@@ -77,6 +127,8 @@ public class EfPlayerRepository : IPlayerRepository
         {
             _context.Players.Remove(player);
             await _context.SaveChangesAsync();
+            await _cache.RemoveAsync(CacheById + id);
+            await _cache.RemoveAsync(CacheByUser + player.UserId);
         }
     }
 
@@ -88,5 +140,10 @@ public class EfPlayerRepository : IPlayerRepository
 
         _context.Players.RemoveRange(players);
         await _context.SaveChangesAsync();
+        await _cache.RemoveAsync(CacheByUser + userId);
+        foreach (var p in players)
+        {
+            await _cache.RemoveAsync(CacheById + p.Id);
+        }
     }
 }

--- a/load-tests/k6/stress-test.js
+++ b/load-tests/k6/stress-test.js
@@ -1,0 +1,37 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 100,
+  duration: '60s',
+};
+
+const baseUrl = __ENV.API_URL || 'http://localhost:5000';
+
+export function setup() {
+  for (let i = 1; i <= options.vus; i++) {
+    const registerPayload = JSON.stringify({
+      username: `user${i}`,
+      email: `user${i}@test.com`,
+      password: 'P@ssw0rd!'
+    });
+    http.post(`${baseUrl}/api/v1/Auth/register`, registerPayload, { headers: { 'Content-Type': 'application/json' } });
+  }
+}
+
+export default function () {
+  const loginPayload = JSON.stringify({
+    usernameOrEmail: `user${__VU}@test.com`,
+    password: 'P@ssw0rd!'
+  });
+
+  const params = { headers: { 'Content-Type': 'application/json' } };
+  const loginRes = http.post(`${baseUrl}/api/v1/Auth/login`, loginPayload, params);
+  check(loginRes, { 'login status 200': r => r.status === 200 });
+
+  // hit rooms listing as a critical endpoint
+  const roomsRes = http.get(`${baseUrl}/api/v1/Rooms`);
+  check(roomsRes, { 'rooms status 200': r => r.status === 200 || r.status === 204 });
+
+  sleep(1);
+}

--- a/load-tests/k6/stress-test.js
+++ b/load-tests/k6/stress-test.js
@@ -6,14 +6,15 @@ export const options = {
   duration: '60s',
 };
 
-const baseUrl = __ENV.API_URL || 'http://localhost:5000';
+const baseUrl = __ENV.API_URL || 'http://localhost:5284';
 
 export function setup() {
   for (let i = 1; i <= options.vus; i++) {
     const registerPayload = JSON.stringify({
       username: `user${i}`,
       email: `user${i}@test.com`,
-      password: 'P@ssw0rd!'
+      password: 'P@ssw0rd!',
+      confirmPassword: 'P@ssw0rd!'
     });
     http.post(`${baseUrl}/api/v1/Auth/register`, registerPayload, { headers: { 'Content-Type': 'application/json' } });
   }


### PR DESCRIPTION
## Summary
- integrate MiniProfiler for runtime profiling
- cache player queries via Redis and compiled EF queries
- provide k6 stress test script for 100 virtual users
- ensure stress test registers users before login

## Testing
- `dotnet build BattleTanks-Backend/Infrastructure/Infrastructure.csproj -c Release`
- `dotnet build BattleTanks-Backend/BattleTanks-Backend/BattleTanks-Backend.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68bbd7f5e3388330a736714cbcf146ed