### PR TITLE
feat: prevent overlapping players

### DIFF
--- a/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
+++ b/BattleTanks-Frontend/src/app/features/room/room-canvas/room-canvas.component.ts
@@ -256,6 +256,20 @@ export class RoomCanvasComponent implements AfterViewInit, OnDestroy {
         // bottom-right
         if (isBlocked(bottomIdx, rightIdx)) collided = true;
 
+        // Check collisions with other players to prevent overlap
+        if (!collided) {
+          const myId = me?.id ?? null;
+          for (const other of roster) {
+            if (!other.isAlive) continue;
+            if (other.playerId === myId) continue;
+            const dist = Math.hypot(newX - other.x, newY - other.y);
+            if (dist < radius * 2) {
+              collided = true;
+              break;
+            }
+          }
+        }
+
         // Update rotation regardless of collision
         this.rot.set(Math.atan2(ndy, ndx));
 


### PR DESCRIPTION
## Summary
- stop tanks from moving into one another by adding player-player collision checks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be23de14a4833089f031ad58cfddc4